### PR TITLE
Added two methods for setting custom start and high signal delays

### DIFF
--- a/src/DHT11.cpp
+++ b/src/DHT11.cpp
@@ -33,6 +33,28 @@ void DHT11::setDelay(unsigned long delay)
 }
 
 /**
+ * Sets a custom delay for the start signal in milliseconds.
+ * If not set, it defaults to 18 milliseconds.
+ *
+ * @param delayMs: The desired delay in milliseconds for the start signal.
+ */
+void DHT11::setStartSignalDelay(int delayMs)
+{
+  _startSignalDelay = delayMs;
+}
+
+/**
+ * Sets a custom delay for the high signal in microseconds.
+ * If not set, it defaults to 40 µs(microseconds).
+ *
+ * @param delayUs: The desired delay in microseconds for the high signal.
+ */
+void DHT11::setHighSignalDelay(int delayUs)
+{
+  _highSignalDelay = delayUs;
+}
+
+/**
  * Reads raw data from the DHT11 sensor.
  * This method handles the direct communication with the DHT11 sensor and retrieves the raw data.
  * It's used internally by the readTemperature, readHumidity, and readTemperatureHumidity methods.
@@ -118,9 +140,9 @@ void DHT11::startSignal()
 {
   pinMode(_pin, OUTPUT);
   digitalWrite(_pin, LOW);
-  delay(18);
+  delay(_startSignalDelay);
   digitalWrite(_pin, HIGH);
-  delayMicroseconds(40);
+  delayMicroseconds(_highSignalDelay);
   pinMode(_pin, INPUT);
 }
 

--- a/src/DHT11.h
+++ b/src/DHT11.h
@@ -37,6 +37,22 @@ public:
   void setDelay(unsigned long delay);
 
   /**
+   * Sets the delay for the MCU to pull the line low.
+   * If this method is not called, a default delay of 18 milliseconds is used.
+   *
+   * @param delay: Delay duration in milliseconds for the MCU to send a start signal.
+   */
+  void setStartSignalDelay(int delayMs);
+
+  /**
+   * Sets the delay for the MCU to pull the line high.
+   * If this method is not called, a default delay of 40 microseconds is used.
+   *
+   * @param delay: Delay duration in microseconds for MCU to send signal, that it's ready to receive a response.
+   */
+  void setHighSignalDelay(int delayUs);
+
+  /**
    * Reads and returns the humidity from the DHT11 sensor.
    *
    * @return: Humidity value in percentage. Returns DHT11_ERROR_TIMEOUT if reading times out.
@@ -77,6 +93,8 @@ public:
 private:
   int _pin;                     // Pin number used for communication with the DHT11 sensor.
   unsigned long _delayMS = 500; // Default delay in milliseconds between sensor readings.
+  int _startSignalDelay = 18; // Default delay in milliseconds for start signal
+  int _highSignalDelay = 40; // Default delay in microseconds for high signal
 
   /**
    * Private method to read raw data from the DHT11 sensor.


### PR DESCRIPTION
Due to an issue created for different DHT11 model with a different high signal of less than the set one of 40 microseconds. This accommodates custom setting for different start and high signals duration.